### PR TITLE
Added test 'test_bottom_n_counters_none' [Testing PR]

### DIFF
--- a/ci_lab/tests/test_counter.py
+++ b/ci_lab/tests/test_counter.py
@@ -162,6 +162,17 @@ class TestCounterEndpoints:
         # TODO: Add an assertion to check that 'b' is indeed in the response
 
     # ===========================
+    # Test: Retrieve bottom N highest counters when no counters exist
+    # Author: Christopher Vuong
+    # Modification: Ensure the API returns not found.
+    # ===========================
+    def test_bottom_n_counters_none(self, client):
+        """Ensures status not found when counters in empty"""
+        client.post('counters/reset')
+        response = client.get('/counters/bottom/1')
+        assert response.status_code == HTTPStatus.NOT_FOUND
+
+    # ===========================
     # Test: Set a counter to a specific value
     # Author: Student 4
     # Modification: Ensure setting a counter to the same value does nothing.


### PR DESCRIPTION
Added new test to ensure retrieving the bottom n counters when no counters exist returns the not found status (line 85).

Coverage pre-test:
<img width="1160" height="807" alt="image" src="https://github.com/user-attachments/assets/4a2efa0e-3980-4771-8639-03e9752ada25" />

Coverage post-test:
<img width="1156" height="825" alt="image" src="https://github.com/user-attachments/assets/a6e7dafd-fc4b-4bb4-8e8e-531f53e4f7b3" />
